### PR TITLE
Attributes matcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.lock
+coverage

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+require:
+  - rubocop-performance
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Available matchers:
 
 * `expect(document['data']).to have_id('12')`
 * `expect(document['data']).to have_type('users')`
-* `expect(document['data']).to have_attributes(:name, :email)`
+* `expect(document['data']).to have_jsonapi_attributes(:name, :email)`
+* `expect(document['data']).to have_jsonapi_attributes(:name, :email, :country).exactly`
 * `expect(document['data']).to have_attribute(:name).with_value('Lucas')`
 * `expect(document['data']).to have_relationships(:posts, :comments)`
 * `expect(document['data']).to have_relationship(:posts).with_data([{ 'id' => '1', 'type' => 'posts' }])`

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,9 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
 RSpec::Core::RakeTask.new
+RuboCop::RakeTask.new
 
-task default: :spec
+task default: %i[rubocop spec]
 task test: :spec

--- a/jsonapi-rspec.gemspec
+++ b/jsonapi-rspec.gemspec
@@ -1,4 +1,4 @@
-version = File.read(File.expand_path('../VERSION', __FILE__)).strip
+version = File.read(File.expand_path('VERSION', __dir__)).strip
 
 Gem::Specification.new do |spec|
   spec.name          = 'jsonapi-rspec'
@@ -15,7 +15,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rspec-expectations'
 
-  spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rubocop-performance'
   spec.add_development_dependency 'simplecov'
 end

--- a/lib/jsonapi/rspec/attributes.rb
+++ b/lib/jsonapi/rspec/attributes.rb
@@ -13,11 +13,18 @@ module JSONAPI
         end
       end
 
-      ::RSpec::Matchers.define :have_attributes do |*attrs|
+      ::RSpec::Matchers.define :have_jsonapi_attributes do |*attrs|
         match do |actual|
           return false unless actual.key?('attributes')
 
-          attrs.all? { |attr| actual['attributes'].key?(attr.to_s) }
+          counted = (attrs.size == actual['attributes'].size) if @exactly
+
+          (attrs.map(&:to_s) - actual['attributes'].keys).empty? &&
+            (counted == @exactly)
+        end
+
+        chain :exactly do
+          @exactly = true
         end
       end
     end

--- a/lib/jsonapi/rspec/relationships.rb
+++ b/lib/jsonapi/rspec/relationships.rb
@@ -17,7 +17,8 @@ module JSONAPI
           if !(actual['relationships'] || {}).key?(rel.to_s)
             "expected #{actual} to have relationship #{rel}"
           else
-            "expected #{actual['relationships'][rel.to_s]} to have data #{@data_val}"
+            "expected #{actual['relationships'][rel.to_s]} " \
+              "to have data #{@data_val}"
           end
         end
       end

--- a/spec/jsonapi/attributes_spec.rb
+++ b/spec/jsonapi/attributes_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe JSONAPI::RSpec do
+  let(:doc) do
+    {
+      'attributes' => {
+        'one' => 1,
+        'two' => 2,
+        'four' => 3
+      }
+    }
+  end
+
+  describe '#have_attribute' do
+    it { expect(doc).to have_attribute(:one) }
+    it { expect(doc).not_to have_attribute(:five) }
+  end
+
+  describe '#have_jsonapi_attributes' do
+    it { expect(doc).to have_jsonapi_attributes(:one, :two) }
+    it { expect(doc).not_to have_jsonapi_attributes(:two, :five) }
+    it { expect(doc).to have_jsonapi_attributes(:one, :two, :four).exactly }
+    it { expect(doc).not_to have_jsonapi_attributes(:one).exactly }
+  end
+end

--- a/spec/jsonapi/jsonapi_object_spec.rb
+++ b/spec/jsonapi/jsonapi_object_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe JSONAPI::RSpec, '#have_jsonapi_object' do
   context 'when providing no value' do
     it 'succeeds when jsonapi object is present' do
-      expect('jsonapi' => { 'version' => '1.0'}).to have_jsonapi_object
+      expect('jsonapi' => { 'version' => '1.0' }).to have_jsonapi_object
     end
 
     it 'fails when jsonapi object is absent' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'jsonapi/rspec'
 SimpleCov.start do
   add_filter '/spec/'
 end
+SimpleCov.minimum_coverage 90
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|


### PR DESCRIPTION
## What is the current behavior?

There's a conflicting matcher named `have_attributes`, with the `rspec-expectations` gem.

## What is the new behavior?

The old matcher is now `have_jsonapi_attributes`.

Support for #12 was also added.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
