### PR TITLE
Make #have_relationships accept symbols

### DIFF
--- a/lib/jsonapi/rspec/relationships.rb
+++ b/lib/jsonapi/rspec/relationships.rb
@@ -26,7 +26,7 @@ module JSONAPI
         match do |actual|
           return false unless actual.key?('relationships')
 
-          rels.all? { |rel| actual['relationships'].key?(rel) }
+          rels.all? { |rel| actual['relationships'].key?(rel.to_s) }
         end
       end
     end

--- a/spec/jsonapi/relationships_spec.rb
+++ b/spec/jsonapi/relationships_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe JSONAPI::RSpec do
+  let(:doc) do
+    JSON.parse('{"relationships": {"videos": [], "images": []}}')
+  end
+  context '#have_relationships' do
+    it 'succeeds when relationships are strings' do
+      expect(doc).to have_relationships('videos', 'images')
+    end
+
+    it 'succeeds when relationships are symbols' do
+      expect(doc).to have_relationships(:videos, :images)
+    end
+  end
+end


### PR DESCRIPTION
## What is the current behavior?
I noticed that the `have_relationships` behavior mentioned in README.md doesn't work with a parsed JSON object if I pass symbols as described in the docs:
`expect(document['data']).to have_relationships(:posts, :comments) `

## What is the new behavior?
Now, `have_relationships` works both with symbols and strings.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
