### PR TITLE
Align have_relationship matcher with readme and add support for Symbol or String parameters

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require ./spec/spec_helper.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,52 @@
 require:
   - rubocop-performance
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*.rb'
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 
 Style/Documentation:
   Enabled: false
+
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Style/ExponentialNotation:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+Style/RedundantRegexpEscape:
+  Enabled: true
+
+Style/SlicingWithRange:
+  Enabled: true
+

--- a/lib/jsonapi/rspec/jsonapi_object.rb
+++ b/lib/jsonapi/rspec/jsonapi_object.rb
@@ -4,7 +4,7 @@ module JSONAPI
       ::RSpec::Matchers.define :have_jsonapi_object do |val|
         match do |actual|
           actual.key?('jsonapi') &&
-            (!val || actual['jsonapi'] == val)
+            (!val || actual['jsonapi'] == JSON.parse(JSON.generate(val)))
         end
       end
     end

--- a/lib/jsonapi/rspec/meta.rb
+++ b/lib/jsonapi/rspec/meta.rb
@@ -4,7 +4,7 @@ module JSONAPI
       ::RSpec::Matchers.define :have_meta do |val|
         match do |actual|
           actual.key?('meta') &&
-            (!val || actual['meta'] == val)
+            (!val || actual['meta'] == JSON.parse(JSON.generate(val)))
         end
       end
     end

--- a/lib/jsonapi/rspec/relationships.rb
+++ b/lib/jsonapi/rspec/relationships.rb
@@ -27,7 +27,7 @@ module JSONAPI
         match do |actual|
           return false unless actual.key?('relationships')
 
-          rels.all? { |rel| actual['relationships'].key?(rel) }
+          rels.all? { |rel| actual['relationships'].key?(rel.to_s) }
         end
       end
     end

--- a/lib/jsonapi/rspec/relationships.rb
+++ b/lib/jsonapi/rspec/relationships.rb
@@ -5,7 +5,7 @@ module JSONAPI
         match do |actual|
           return false unless (actual['relationships'] || {}).key?(rel.to_s)
 
-          !@data_set || actual['relationships'][rel.to_s]['data'] == @data_val
+          !@data_set || actual['relationships'][rel.to_s]['data'] == JSON.parse(JSON.generate(@data_val))
         end
 
         chain :with_data do |val|

--- a/lib/jsonapi/rspec/type.rb
+++ b/lib/jsonapi/rspec/type.rb
@@ -2,7 +2,7 @@ module JSONAPI
   module RSpec
     module Type
       ::RSpec::Matchers.define :have_type do |expected|
-        match { |actual| actual['type'] == expected }
+        match { |actual| actual['type'] == expected.to_s }
       end
     end
   end

--- a/spec/jsonapi/attributes_spec.rb
+++ b/spec/jsonapi/attributes_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe JSONAPI::RSpec do
   let(:doc) do
     {

--- a/spec/jsonapi/attributes_spec.rb
+++ b/spec/jsonapi/attributes_spec.rb
@@ -11,13 +11,19 @@ RSpec.describe JSONAPI::RSpec do
 
   describe '#have_attribute' do
     it { expect(doc).to have_attribute(:one) }
+    it { expect(doc).to have_attribute('one') }
     it { expect(doc).not_to have_attribute(:five) }
+    it { expect(doc).not_to have_attribute('five') }
   end
 
   describe '#have_jsonapi_attributes' do
     it { expect(doc).to have_jsonapi_attributes(:one, :two) }
+    it { expect(doc).to have_jsonapi_attributes('one', 'two') }
     it { expect(doc).not_to have_jsonapi_attributes(:two, :five) }
+    it { expect(doc).not_to have_jsonapi_attributes('two', 'five') }
     it { expect(doc).to have_jsonapi_attributes(:one, :two, :four).exactly }
-    it { expect(doc).not_to have_jsonapi_attributes(:one).exactly }
+    it { expect(doc).to have_jsonapi_attributes('one', 'two', 'four').exactly }
+    it { expect(doc).not_to have_jsonapi_attributes('one').exactly }
+    it { expect(doc).not_to have_jsonapi_attributes('one').exactly }
   end
 end

--- a/spec/jsonapi/id_spec.rb
+++ b/spec/jsonapi/id_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe JSONAPI::RSpec, '#have_id' do
   it 'succeeds when id matches' do
     expect('id' => 'foo').to have_id('foo')

--- a/spec/jsonapi/jsonapi_object_spec.rb
+++ b/spec/jsonapi/jsonapi_object_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe JSONAPI::RSpec, '#have_jsonapi_object' do
   context 'when providing no value' do
     it 'succeeds when jsonapi object is present' do

--- a/spec/jsonapi/jsonapi_object_spec.rb
+++ b/spec/jsonapi/jsonapi_object_spec.rb
@@ -11,17 +11,18 @@ RSpec.describe JSONAPI::RSpec, '#have_jsonapi_object' do
 
   context 'when providing a value' do
     it 'succeeds when jsonapi object matches' do
-      expect('jsonapi' => { 'version' => '1.0' })
-        .to have_jsonapi_object('version' => '1.0')
+      expect('jsonapi' => { 'version' => '1.0' }).to have_jsonapi_object('version' => '1.0')
+      expect('jsonapi' => { 'version' => '1.0' }).to have_jsonapi_object(version: '1.0')
     end
 
     it 'fails when jsonapi object mismatches' do
-      expect('jsonapi' => { 'version' => '2.0' })
-        .not_to have_jsonapi_object('version' => '1.0')
+      expect('jsonapi' => { 'version' => '2.0' }).not_to have_jsonapi_object('version' => '1.0')
+      expect('jsonapi' => { 'version' => '2.0' }).not_to have_jsonapi_object(version: '1.0')
     end
 
     it 'fails when jsonapi object is absent' do
       expect({}).not_to have_jsonapi_object('version' => '1.0')
+      expect({}).not_to have_jsonapi_object(version: '1.0')
     end
   end
 end

--- a/spec/jsonapi/links_spec.rb
+++ b/spec/jsonapi/links_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe JSONAPI::RSpec do
   let(:doc) do
     {

--- a/spec/jsonapi/links_spec.rb
+++ b/spec/jsonapi/links_spec.rb
@@ -11,12 +11,18 @@ RSpec.describe JSONAPI::RSpec do
   context '#have_link' do
     it { expect(doc).to have_link(:self) }
     it { expect(doc).to have_link(:self).with_value('self_link') }
+    it { expect(doc).to have_link('self') }
+    it { expect(doc).to have_link('self').with_value('self_link') }
     it { expect(doc).not_to have_link(:self).with_value('any_link') }
     it { expect(doc).not_to have_link(:any) }
+    it { expect(doc).not_to have_link('self').with_value('any_link') }
+    it { expect(doc).not_to have_link('any') }
   end
 
   context '#have_links' do
     it { expect(doc).to have_links(:self, :related) }
     it { expect(doc).not_to have_links(:self, :other) }
+    it { expect(doc).to have_links('self', 'related') }
+    it { expect(doc).not_to have_links('self', 'other') }
   end
 end

--- a/spec/jsonapi/meta_spec.rb
+++ b/spec/jsonapi/meta_spec.rb
@@ -11,14 +11,17 @@ RSpec.describe JSONAPI::RSpec, '#have_meta' do
 
   context 'when providing a value' do
     it 'succeeds when meta matches' do
-      expect('meta' => { foo: 'bar' }).to have_meta(foo: 'bar')
+      expect('meta' => { 'foo' => 'bar' }).to have_meta({ 'foo' => 'bar' })
+      expect('meta' => { 'foo' => 'bar' }).to have_meta(foo: 'bar')
     end
 
     it 'fails when meta mismatches' do
-      expect('meta' => { foo: 'bar' }).not_to have_meta(bar: 'baz')
+      expect('meta' => { 'foo' => 'bar' }).not_to have_meta({ 'foo' => 'baz' })
+      expect('meta' => { 'foo' => 'bar' }).not_to have_meta(bar: 'baz')
     end
 
     it 'fails when meta is absent' do
+      expect({}).not_to have_meta({ 'foo' => 'bar' })
       expect({}).not_to have_meta(foo: 'bar')
     end
   end

--- a/spec/jsonapi/meta_spec.rb
+++ b/spec/jsonapi/meta_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe JSONAPI::RSpec, '#have_meta' do
   context 'when providing no value' do
     it 'succeeds when meta is present' do

--- a/spec/jsonapi/relationships_spec.rb
+++ b/spec/jsonapi/relationships_spec.rb
@@ -23,11 +23,31 @@ RSpec.describe JSONAPI::RSpec do
 
   describe '#have_jsonapi_attributes' do
     it { expect(doc).to have_relationship(:posts) }
+    it { expect(doc).to have_relationship('posts') }
     it { expect(doc).not_to have_relationship(:mails) }
+    it { expect(doc).not_to have_relationship('mails') }
     it { expect(doc).to have_relationship(:posts).with_data({ 'id' => '1', 'type' => 'posts' }) }
+    it { expect(doc).to have_relationship('posts').with_data({ 'id' => '1', 'type' => 'posts' }) }
+    it { expect(doc).to have_relationship(:posts).with_data({ id: '1', type: 'posts' }) }
+    it { expect(doc).to have_relationship('posts').with_data({ id: '1', type: 'posts' }) }
     it do
       expect(doc).to have_relationship(:comments).with_data(
         [{ 'id' => '1', 'type' => 'posts' }, { 'id' => '2', 'type' => 'hides' }]
+      )
+    end
+    it do
+      expect(doc).to have_relationship('comments').with_data(
+        [{ 'id' => '1', 'type' => 'posts' }, { 'id' => '2', 'type' => 'hides' }]
+      )
+    end
+    it do
+      expect(doc).to have_relationship(:comments).with_data(
+        [{ id: '1', type:  'posts' }, { id: '2', type: 'hides' }]
+      )
+    end
+    it do
+      expect(doc).to have_relationship('comments').with_data(
+        [{ id: '1', type:  'posts' }, { id: '2', type: 'hides' }]
       )
     end
   end
@@ -36,5 +56,6 @@ RSpec.describe JSONAPI::RSpec do
     it { expect(doc).to have_relationships(:posts, :comments) }
     it { expect(doc).to have_relationships('posts', 'comments') }
     it { expect(doc).not_to have_relationships(:posts, :comments, :mails) }
+    it { expect(doc).not_to have_relationships('posts', 'comments', 'mails') }
   end
 end

--- a/spec/jsonapi/relationships_spec.rb
+++ b/spec/jsonapi/relationships_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe JSONAPI::RSpec do
+  let(:doc) do
+    {
+      'relationships' => {
+        'posts' => {
+          'data' => {
+            'id' => '1',
+            'type' => 'posts'
+          }
+        },
+        'comments' => {
+          'data' => [{
+            'id' => '1',
+            'type' => 'posts'
+          }, {
+            'id' => '2',
+            'type' => 'hides'
+          }]
+        }
+      }
+    }
+  end
+
+  describe '#have_jsonapi_attributes' do
+    it { expect(doc).to have_relationship(:posts) }
+    it { expect(doc).not_to have_relationship(:mails) }
+    it { expect(doc).to have_relationship(:posts).with_data({ 'id' => '1', 'type' => 'posts' }) }
+    it do
+      expect(doc).to have_relationship(:comments).with_data(
+        [{ 'id' => '1', 'type' => 'posts' }, { 'id' => '2', 'type' => 'hides' }]
+      )
+    end
+  end
+
+  describe '#have_relationships' do
+    it { expect(doc).to have_relationships(:posts, :comments) }
+    it { expect(doc).to have_relationships('posts', 'comments') }
+    it { expect(doc).not_to have_relationships(:posts, :comments, :mails) }
+  end
+end

--- a/spec/jsonapi/type_spec.rb
+++ b/spec/jsonapi/type_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe JSONAPI::RSpec, '#have_type' do
   it 'succeeds when type matches' do
     expect('type' => 'foo').to have_type('foo')

--- a/spec/jsonapi/type_spec.rb
+++ b/spec/jsonapi/type_spec.rb
@@ -2,9 +2,16 @@ RSpec.describe JSONAPI::RSpec, '#have_type' do
   it 'succeeds when type matches' do
     expect('type' => 'foo').to have_type('foo')
   end
+  it 'succeeds when type (as symbol) matches' do
+    expect('type' => 'foo').to have_type(:foo)
+  end
 
   it 'fails when type mismatches' do
     expect('type' => 'foo').not_to have_type('bar')
+  end
+
+  it 'fails when type (as symbol) mismatches' do
+    expect('type' => 'foo').not_to have_type(:bar)
   end
 
   it 'fails when type is absent' do


### PR DESCRIPTION
## What is the current behavior?

The current README file provides an example usage for the matcher of 
* `expect(document['data']).to have_relationships(:posts, :comments)`
With the current implementation of have_relationships, this fails as it does not to_s the relationship array values provided.  

PR #15 was rejected as it only added Symbol parameters to the relationships matcher without updating all matchers.

This PR includes support for symbol parameters in all matchers

## What is the new behavior?

All matchers now accept strings or symbols (and string or symbol keyed hashes where applicable)
Relationships matcher now has a spec to test it.

## Checklist

Please make sure the following requirements are complete:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [X] All automated checks pass (CI/CD)
