### PR TITLE
Fix "undefined method `configure` bug

### DIFF
--- a/jsonapi-rspec.gemspec
+++ b/jsonapi-rspec.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['README.md', 'lib/**/*']
   spec.require_path  = 'lib'
 
+  spec.add_dependency 'rspec-core'
   spec.add_dependency 'rspec-expectations'
 
   spec.add_development_dependency 'rake'

--- a/lib/jsonapi/rspec.rb
+++ b/lib/jsonapi/rspec.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'rspec/matchers'
+require 'rspec/core'
 require 'jsonapi/rspec/id'
 require 'jsonapi/rspec/type'
 require 'jsonapi/rspec/attributes'


### PR DESCRIPTION
Due to rake eagerly loading the jsonapi-rspec gem before the RSpec:Core module,  configure isn't available when rspec.rb tries to use it.  Requiring rspec/core resolves this issue.

## What is the current behavior?

rake is failing with:
```rake aborted!
NoMethodError: undefined method `configure' for RSpec:Module
.../config/application.rb:20:in `<top (required)>'
.../Rakefile:4:in `require_relative'
.../Rakefile:4:in `<top (required)>'

Caused by:
LoadError: cannot load such file -- jsonapi-rspec
.../config/application.rb:20:in `<top (required)>'
.../Rakefile:4:in `require_relative'
.../Rakefile:4:in `<top (required)>'
(See full trace by running task with --trace)
```

## What is the new behavior?

rake works as expected

## Checklist

Please make sure the following requirements are complete:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes /  features)
- [X] All automated checks pass (CI/CD)
