### PR TITLE
Modify have_meta to include an exactly chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Available matchers:
 * `expect(document['data']).to have_link(:self).with_value('http://api.example.com/users/12')`
 * `expect(document).to have_meta`
 * `expect(document).to have_meta('foo' => 'bar')`
+* `expect(document).to have_meta('foo' => 'bar', 'fum' => 'baz').exactly`
 * `expect(document).to have_jsonapi_object`
 * `expect(document).to have_jsonapi_object('version' => '1.0')`
 

--- a/lib/jsonapi/rspec/meta.rb
+++ b/lib/jsonapi/rspec/meta.rb
@@ -4,9 +4,17 @@ module JSONAPI
       ::RSpec::Matchers.define :have_meta do |val|
         match do |actual|
           actual = JSONAPI::RSpec.as_indifferent_hash(actual)
-          val = JSONAPI::RSpec.as_indifferent_hash(val)
+          return false unless actual.key?('meta')
+          return true unless val
 
-          actual.key?('meta') && (!val || actual['meta'] == val)
+          val = JSONAPI::RSpec.as_indifferent_hash(val)
+          return false unless val <= actual['meta']
+
+          !@exactly || (@exactly && val.size == actual['meta'].size)
+        end
+
+        chain :exactly do
+          @exactly = true
         end
       end
     end

--- a/spec/jsonapi/meta_spec.rb
+++ b/spec/jsonapi/meta_spec.rb
@@ -1,9 +1,18 @@
 require 'spec_helper'
 
 RSpec.describe JSONAPI::RSpec, '#have_meta' do
+  let(:doc) do
+    {
+      'meta' => {
+        'one' => 'I',
+        'two' => 'II',
+        'three' => 'III'
+      }
+    }
+  end
   context 'when providing no value' do
     it 'succeeds when meta is present' do
-      expect('meta' => {}).to have_meta
+      expect(doc).to have_meta
     end
 
     it 'fails when meta is absent' do
@@ -17,16 +26,24 @@ RSpec.describe JSONAPI::RSpec, '#have_meta' do
       after(:all) { ::RSpec.configuration.jsonapi_indifferent_hash = false }
 
       it do
-        expect('meta' => { 'foo' => 'bar' }).to have_meta(foo: :bar)
+        expect(doc).to have_meta(one: 'I')
       end
     end
 
-    it 'succeeds when meta matches' do
-      expect('meta' => { foo: 'bar' }).to have_meta(foo: 'bar')
+    it 'succeeds when meta includes the value' do
+      expect(doc).to have_meta('one' => 'I')
     end
 
-    it 'fails when meta mismatches' do
-      expect('meta' => { foo: 'bar' }).not_to have_meta(bar: 'baz')
+    it 'fails when meta does not include the value' do
+      expect(doc).not_to have_meta('one' => 'II')
+    end
+
+    it 'succeeds when meta exactly matches the value' do
+      expect(doc).to have_meta({ 'one' => 'I', 'two' => 'II', 'three' => 'III' }).exactly
+    end
+
+    it 'succeeds when meta does not exactly match the value' do
+      expect(doc).not_to have_meta({ 'one' => 'foo', 'two' => 'II', 'three' => 'III' }).exactly
     end
 
     it 'fails when meta is absent' do


### PR DESCRIPTION
## What is the current behavior?

the have_meta matcher only provides exact match functionality

## What is the new behavior?

the have_meta matcher now operates as an includes matcher, with an optional exactly chain to force an exact match

## Checklist

Please make sure the following requirements are complete:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [X] All automated checks pass (CI/CD)
