### PR TITLE
Add support for `.exactly` to the `have_relationships(...)` matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Available matchers:
 * `expect(document['data']).to have_jsonapi_attributes(:name, :email, :country).exactly`
 * `expect(document['data']).to have_attribute(:name).with_value('Lucas')`
 * `expect(document['data']).to have_relationships(:posts, :comments)`
+* `expect(document['data']).to have_relationships(:posts, :comments, :likes).exactly`
 * `expect(document['data']).to have_relationship(:posts).with_data([{ 'id' => '1', 'type' => 'posts' }])`
 * `expect(document['data']['relationships']['posts']).to have_links(:self, :related)`
 * `expect(document['data']).to have_link(:self).with_value('http://api.example.com/users/12')`

--- a/lib/jsonapi/rspec/relationships.rb
+++ b/lib/jsonapi/rspec/relationships.rb
@@ -29,7 +29,14 @@ module JSONAPI
           actual = JSONAPI::RSpec.as_indifferent_hash(actual)
           return false unless actual.key?('relationships')
 
-          rels.map(&:to_s).all? { |rel| actual['relationships'].key?(rel) }
+          counted = (rels.size == actual['relationships'].keys.size) if @exactly
+
+          rels.map(&:to_s).all? { |rel| actual['relationships'].key?(rel) } \
+            && (counted == @exactly)
+        end
+
+        chain :exactly do
+          @exactly = true
         end
       end
     end

--- a/spec/jsonapi/relationships_spec.rb
+++ b/spec/jsonapi/relationships_spec.rb
@@ -23,6 +23,9 @@ RSpec.describe JSONAPI::RSpec, '#have_relationship(s)' do
   it { expect(doc).not_to have_relationship('authors') }
   it { expect(doc).to have_relationship('user') }
 
+  it { expect(doc).to have_relationships('user', 'comments').exactly }
+  it { expect(doc).not_to have_relationships('comments').exactly }
+
   it do
     expect(doc).to have_relationship('user').with_data(
       { 'id' => '1', 'type' => 'user' }


### PR DESCRIPTION
## What is the current behavior?

Currently, the library supports `have_attributes(attr1, attr2, etc).exactly` to verify that the specified attributes are the complete set of attributes in the node. However `have_relationships(rel1, rel2).exactly` is not supported.

## What is the new behavior?

`have_relationships(rel1, rel2).exactly` is supported and will fail if any other relationships are present besides the specified ones.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
