### PR TITLE
Improved failure message and description for `have_attribute` matcher

### DIFF
--- a/lib/jsonapi/rspec/attributes.rb
+++ b/lib/jsonapi/rspec/attributes.rb
@@ -4,14 +4,46 @@ module JSONAPI
       ::RSpec::Matchers.define :have_attribute do |attr|
         match do |actual|
           actual = JSONAPI::RSpec.as_indifferent_hash(actual)
-          (actual['attributes'] || {}).key?(attr.to_s) &&
-            (!@val_set || actual['attributes'][attr.to_s] == @val)
+          @attributes_node = actual['attributes']
+          
+          return false unless @attributes_node
+
+          @has_attribute = @attributes_node.key?(attr.to_s)
+          if @has_attribute && @should_match_value
+            @actual_value = @attributes_node[attr.to_s]
+
+            # Work nicely with diffable
+            @actual = @actual_value
+            @expected = @expected_value
+
+            return @actual == @expected
+          end
+          @has_attribute
         end
 
-        chain :with_value do |val|
-          @val_set = true
-          @val = val
+        chain :with_value do |expected_value|
+          @should_match_value = true
+          @expected_value = expected_value
         end
+
+        description do
+          result = "have attribute #{attr.inspect}"
+          if @should_match_value
+            result << " with value #{@expected_value.inspect}"
+          end
+          result
+        end
+
+        failure_message do |actual|
+          if @has_attribute
+            "expected `#{attr}` attribute to have value `#{@expected}` but was `#{@actual}`"
+          else
+            "expected attributes to include `#{attr}`. Actual attributes were #{@attributes_node.keys}"
+          end
+        end
+
+        diffable
+        attr_reader :actual, :expected
       end
 
       ::RSpec::Matchers.define :have_jsonapi_attributes do |*attrs|

--- a/spec/jsonapi/attributes_spec.rb
+++ b/spec/jsonapi/attributes_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe JSONAPI::RSpec do
       'attributes' => {
         'one' => 1,
         'two' => 2,
-        'four' => 3
+        'four' => 3,
+        'six' => { foo: 'bar' }
       }
     }
   end
@@ -14,12 +15,33 @@ RSpec.describe JSONAPI::RSpec do
   describe '#have_attribute' do
     it { expect(doc).to have_attribute(:one) }
     it { expect(doc).not_to have_attribute(:five) }
+    it { expect(doc).to have_attribute(:one).with_value(1) }
+    it { expect(doc).not_to have_attribute(:one).with_value(2) }
+    it { expect(doc).to have_attribute(:six).with_value(foo: 'bar') }
+
+    it 'rejects with an appropriate failure message' do
+      expect {
+        expect(doc).to have_attribute(:three)
+      }.to fail_with('expected attributes to include `three`. Actual attributes were ["one", "two", "four", "six"]')
+    end
+
+    it 'rejects with an appropriate failure message for chained with_value, simple values' do
+      expect {
+        expect(doc).to have_attribute(:one).with_value(2)
+      }.to fail_with('expected `one` attribute to have value `2` but was `1`')
+    end
+
+    it 'rejects with an appropriate failure message for chained with_value, complex values show diff' do
+      expect {
+        expect(doc).to have_attribute(:six).with_value(bar: 'baz')
+      }.to fail_with(/expected `six` attribute to have value `{:bar=>"baz"}` but was `{:foo=>"bar"}`.*Diff:/m)
+    end
   end
 
   describe '#have_jsonapi_attributes' do
     it { expect(doc).to have_jsonapi_attributes(:one, :two) }
     it { expect(doc).not_to have_jsonapi_attributes(:two, :five) }
-    it { expect(doc).to have_jsonapi_attributes(:one, :two, :four).exactly }
+    it { expect(doc).to have_jsonapi_attributes(:one, :two, :four, :six).exactly }
     it { expect(doc).not_to have_jsonapi_attributes(:one).exactly }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,27 @@ SimpleCov.start do
 end
 SimpleCov.minimum_coverage 90
 
+module FailMatchers
+  def fail
+    raise_error(RSpec::Expectations::ExpectationNotMetError)
+  end
+
+  def fail_with(message)
+    raise_error(RSpec::Expectations::ExpectationNotMetError, message)
+  end
+
+  def fail_including(snippet)
+    raise_error(
+      RSpec::Expectations::ExpectationNotMetError,
+      a_string_including(snippet)
+    )
+  end
+end
+
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.include FailMatchers
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end


### PR DESCRIPTION
## What is the current behavior?

![image](https://user-images.githubusercontent.com/353/88366269-4fd29280-cdbb-11ea-90e4-91b687f1f9b7.png)

## What is the new behavior?

![image](https://user-images.githubusercontent.com/353/88366176-097d3380-cdbb-11ea-93ed-16e64bedfcda.png)

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)- *not applicable*
- [ ] All automated checks pass (CI/CD)
