### PR TITLE
`have_type` comparison consistency improvements

### DIFF
--- a/lib/jsonapi/rspec/type.rb
+++ b/lib/jsonapi/rspec/type.rb
@@ -3,7 +3,7 @@ module JSONAPI
     module Type
       ::RSpec::Matchers.define :have_type do |expected|
         match do |actual|
-          JSONAPI::RSpec.as_indifferent_hash(actual)['type'] == expected.to_s
+          JSONAPI::RSpec.as_indifferent_hash(actual)['type'].to_s == expected.to_s
         end
       end
     end

--- a/spec/jsonapi/type_spec.rb
+++ b/spec/jsonapi/type_spec.rb
@@ -5,6 +5,16 @@ RSpec.describe JSONAPI::RSpec, '#have_type' do
     expect('type' => 'foo').to have_type('foo')
   end
 
+  context 'with mismatching classes' do
+    it 'succeeds when type is a symbol' do
+      expect('type' => :foo).to have_type('foo')
+    end
+
+    it 'succeeds when argument is a symbol' do
+      expect('type' => 'foo').to have_type(:foo)
+    end
+  end
+
   it 'fails when type mismatches' do
     expect('type' => 'foo').not_to have_type('bar')
   end


### PR DESCRIPTION
## What is the current behavior?

Currently, we're assuming that actual `type` is always a string, which causes test failures whenever `type` is a symbol.
In my case it is caused by [those lines](https://github.com/jsonapi-rb/jsonapi-serializable/blob/02e9e4df43a94528a56ffc4d71a630e81e9841f2/lib/jsonapi/serializable/resource.rb#L23-L27) of `JSONAPI::Serializable::Resource`: 
```ruby
        @_type = if (b = self.class.type_block)
                   instance_eval(&b).to_sym
                 else
                   self.class.type_val || :unknown
                 end
```
It always transforms `type` to a symbol so the tests fail as `have_type` compares it to a string.

## What is the new behavior?

The actual `type` is transformed into a string for a comparison consistency.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
