### PR TITLE
Allow to use symbols in type matcher

### DIFF
--- a/lib/jsonapi/rspec/type.rb
+++ b/lib/jsonapi/rspec/type.rb
@@ -3,7 +3,7 @@ module JSONAPI
     module Type
       ::RSpec::Matchers.define :have_type do |expected|
         match do |actual|
-          JSONAPI::RSpec.as_indifferent_hash(actual)['type'] == expected.to_s
+          JSONAPI::RSpec.as_indifferent_hash(actual)['type'].to_s == expected.to_s
         end
       end
     end

--- a/spec/jsonapi/type_spec.rb
+++ b/spec/jsonapi/type_spec.rb
@@ -12,4 +12,8 @@ RSpec.describe JSONAPI::RSpec, '#have_type' do
   it 'fails when type is absent' do
     expect({}).not_to have_type('foo')
   end
+
+  it 'succeeds when expected type is a symbol' do
+    expect('type' => :foo).to have_type(:foo)
+  end
 end


### PR DESCRIPTION
## What is the current behavior?

expected hash should contain type as a string value

## What is the new behavior?

allow use symbols and strings for type matcher

## Example
if use [jsonapi-serializer](https://github.com/jsonapi-serializer/)

```ruby
serializer.new(entity, is_collection: false).serializable_hash
```

it returns hash where type is as a symbol
```
{:data=>
  {:id=>"1010",
   :type=>:timeoffs,
   :attributes=> ...
}
```
and it fails
```
expect(data).to have_type(:timeoffs)
```

To fix this workaround we can use 
```
serializer.new(entity, is_collection: false).serializable_hash.as_json
```
but it requires one unnecessary action to transform all data in hash to strings

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
