### PR TITLE
Check has_attribute instead of actual

### DIFF
--- a/lib/jsonapi/rspec/attributes.rb
+++ b/lib/jsonapi/rspec/attributes.rb
@@ -29,7 +29,7 @@ module JSONAPI
         end
 
         failure_message do |_doc|
-          if @actual
+          if @has_attribute
             "expected `#{attr_name}` attribute " \
               "to have value `#{@expected}` but was `#{@actual}`"
           else


### PR DESCRIPTION
check if attribute key exists instead of checking if attribute value exists, addresses case of attribute value being nil

## What is the current behavior?

If the key is present in the attributes hash but the value of it is nil it will show a test failure message of this:

![Screenshot from 2020-12-18 07-29-55](https://user-images.githubusercontent.com/8441193/102631705-eacd5f80-4102-11eb-86ca-2b5e587c179e.png)

which is clearly incorrect as the key is present in the array

## What is the new behavior?

It will now show the correct error message of a nil value when expecting a different value

![Screenshot from 2020-12-18 07-30-11](https://user-images.githubusercontent.com/8441193/102631716-edc85000-4102-11eb-8aeb-d5f494253314.png)

more helpful error message

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
