### PR TITLE
Convert have_id matcher argument to string.

### DIFF
--- a/lib/jsonapi/rspec/id.rb
+++ b/lib/jsonapi/rspec/id.rb
@@ -3,7 +3,7 @@ module JSONAPI
     module Id
       ::RSpec::Matchers.define :have_id do |expected|
         match do |actual|
-          JSONAPI::RSpec.as_indifferent_hash(actual)['id'] == expected
+          JSONAPI::RSpec.as_indifferent_hash(actual)['id'].to_s == expected.to_s
         end
       end
     end

--- a/spec/jsonapi/id_spec.rb
+++ b/spec/jsonapi/id_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe JSONAPI::RSpec, '#have_id' do
     expect('id' => 'foo').to have_id('foo')
   end
 
+  it 'succeeds when expectation is integer' do
+    expect('id' => '123').to have_id(123)
+  end
+
+  it 'succeeds when id is symbol' do
+    expect('id' => :foo).to have_id('foo')
+  end
+
   it 'fails when id mismatches' do
     expect('id' => 'foo').not_to have_id('bar')
   end


### PR DESCRIPTION
## What is the current behavior?

According to docs this two lines should be equivalent:

```ruby
expect(document['data']).to have_id(12)
expect(document['data']).to have_id('12')
```

But the first line will fail if the `id` value in the hash is a string, and the second line will fail if the `id` value is another type than a string.

## What is the new behavior?

Convert expected value and actual value to a string in the `have_id` matcher.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
