### PR TITLE
Allow matchers in expected value in with_data chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ Checking for an included resource:
 expect(response_body['included'])
   .to include(have_type('posts').and have_id('1'))
 ```
+
+Combining `have_relationship.with_data` matcher with other matchers:
+
+```ruby
+expect(response_body)
+  .to have_relationship(:posts).with_data(include(have_id('1')))
+
+expect(response_body)
+  .to have_relationship(:posts).with_data(all(have_type('post')))
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at

--- a/lib/jsonapi/rspec/relationships.rb
+++ b/lib/jsonapi/rspec/relationships.rb
@@ -6,18 +6,18 @@ module JSONAPI
           actual = JSONAPI::RSpec.as_indifferent_hash(actual)
           return false unless (actual['relationships'] || {}).key?(rel.to_s)
 
-          !@data_set || actual['relationships'][rel.to_s]['data'] == @data_val
+          !@data_set || values_match?(@data_val, actual['relationships'][rel.to_s]['data'])
         end
 
         chain :with_data do |val|
           @data_set = true
-          @data_val = JSONAPI::RSpec.as_indifferent_hash(val)
+          @data_val = ::RSpec::Matchers.is_a_matcher?(val) ? val : JSONAPI::RSpec.as_indifferent_hash(val)
         end
 
         failure_message do |actual|
           if (actual['relationships'] || {}).key?(rel.to_s)
             "expected #{actual['relationships'][rel.to_s]} " \
-              "to have data #{@data_val}"
+              "to have data #{description_of(@data_val)}"
           else
             "expected #{actual} to have relationship #{rel}"
           end

--- a/spec/jsonapi/relationships_spec.rb
+++ b/spec/jsonapi/relationships_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe JSONAPI::RSpec, '#have_relationship(s)' do
     )
   end
 
+  it do
+    expect(doc).to have_relationship('comments').with_data(
+      include(have_id('1').and(have_type('comment')))
+    )
+  end
+
   context 'with jsonapi indifferent hash enabled' do
     before(:all) { ::RSpec.configuration.jsonapi_indifferent_hash = true }
     after(:all) { ::RSpec.configuration.jsonapi_indifferent_hash = false }


### PR DESCRIPTION
## What is the current behavior?

In `have_relationship.with_data` you can pass only actual values, it doesn't work with other matches.

## What is the new behavior?

Add support for matches to `have_relationship.with_data` to allow write more customizable expectations, like expecting all records to have some type, or expecting to have record with some id, ignoring others:

```ruby
doc = {
  'relationships' => {
    'comments' => {
      'data' => [
        { 'id' => '1', 'type' => 'comment' },
        { 'id' => '2', 'type' => 'comment' }
      ]
    }
  }
}

expect(doc).to have_relationship('comments').with_data(all(have_type('comment')))
expect(doc).to have_relationship('comments').with_data(include(have_id('1')))
```

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
