### PR TITLE
Add Ruby 3.0, 3.1, and ruby-head to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on: [push, pull_request]
 
 jobs:
   ruby_rails_test_matrix:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        ruby: [2.4, 2.7]
+        ruby: [2.4, 2.7, '3.0', 3.1, ruby-head]
 
     steps:
     - uses: actions/checkout@master
@@ -16,6 +16,6 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-
+        bundler-cache: true # 'bundle install' and cache
     - name: Runs code QA and tests
-      run: bundle && rake
+      run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.4, 2.7, '3.0', 3.1, ruby-head]
+        ruby: [2.4, 2.7, '3.0', 3.1, 3.2, ruby-head]
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
 
     - uses: ruby/setup-ruby@v1
       with:

--- a/jsonapi-rspec.gemspec
+++ b/jsonapi-rspec.gemspec
@@ -20,4 +20,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop-performance'
   spec.add_development_dependency 'simplecov'
+
+  spec.metadata = {
+    'rubygems_mfa_required' => 'true'
+  }
 end

--- a/spec/jsonapi/jsonapi_object_spec.rb
+++ b/spec/jsonapi/jsonapi_object_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe JSONAPI::RSpec, '#have_jsonapi_object' do
 
   context 'when providing a value' do
     context 'with jsonapi indifferent hash enabled' do
-      before(:all) { ::RSpec.configuration.jsonapi_indifferent_hash = true }
-      after(:all) { ::RSpec.configuration.jsonapi_indifferent_hash = false }
+      before(:all) { RSpec.configuration.jsonapi_indifferent_hash = true }
+      after(:all) { RSpec.configuration.jsonapi_indifferent_hash = false }
 
       it do
         expect('jsonapi' => { 'version' => '1.0' })

--- a/spec/jsonapi/meta_spec.rb
+++ b/spec/jsonapi/meta_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe JSONAPI::RSpec, '#have_meta' do
 
   context 'when providing a value' do
     context 'with jsonapi indifferent hash enabled' do
-      before(:all) { ::RSpec.configuration.jsonapi_indifferent_hash = true }
-      after(:all) { ::RSpec.configuration.jsonapi_indifferent_hash = false }
+      before(:all) { RSpec.configuration.jsonapi_indifferent_hash = true }
+      after(:all) { RSpec.configuration.jsonapi_indifferent_hash = false }
 
       it do
         expect(doc).to have_meta(one: 'I')

--- a/spec/jsonapi/relationships_spec.rb
+++ b/spec/jsonapi/relationships_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe JSONAPI::RSpec, '#have_relationship(s)' do
   end
 
   context 'with jsonapi indifferent hash enabled' do
-    before(:all) { ::RSpec.configuration.jsonapi_indifferent_hash = true }
-    after(:all) { ::RSpec.configuration.jsonapi_indifferent_hash = false }
+    before(:all) { RSpec.configuration.jsonapi_indifferent_hash = true }
+    after(:all) { RSpec.configuration.jsonapi_indifferent_hash = false }
 
     it { expect(doc).to have_relationships(:user, :comments) }
 

--- a/spec/jsonapi/rspec_spec.rb
+++ b/spec/jsonapi/rspec_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe JSONAPI::RSpec, '#as_indifferent_hash' do
   end
 
   context 'with jsonapi indifferent hash enabled' do
-    before(:all) { ::RSpec.configuration.jsonapi_indifferent_hash = true }
-    after(:all) { ::RSpec.configuration.jsonapi_indifferent_hash = false }
+    before(:all) { RSpec.configuration.jsonapi_indifferent_hash = true }
+    after(:all) { RSpec.configuration.jsonapi_indifferent_hash = false }
 
     it do
       expect(JSONAPI::RSpec.as_indifferent_hash(doc)).to eq(


### PR DESCRIPTION
## What is the current behavior?

CI only runs against Ruby 2.4 and 2.7

## What is the new behavior?

CI runs against Ruby 2.4, 2.7, 3.0, 3.1, and head

To pass Rubocop against a recent version I also added the requirement that gem publishers have MFA configured on Rubygems.

## Checklist

Please make sure the following requirements are complete:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [X] All automated checks pass (CI/CD)
